### PR TITLE
Update FastTree installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ all:
 fasttree:
 	echo $(CWD)	
 	curl "http://microbesonline.org/fasttree/FastTree.c" -o FastTree.c
-	gcc -Wall -O3 -finline-functions -funroll-loops -o FastTree -lm FastTree.c
+	gcc -Wall -O3 -finline-functions -funroll-loops -o FastTree FastTree.c -lm
 	mv $(CWD)/FastTree $(EXTERNAL_CODE)
 	rm FastTree.c
 


### PR DESCRIPTION
We had problems installing big.phylo on Linux. FastTree couldn't compile.
We placed -lm at the end of FastTree compilation command and tried it on Linux and MacOs. It seems to work.
What do you think about it?